### PR TITLE
fix(button): handle error state on onPressed

### DIFF
--- a/lib/buttons/button_common.dart
+++ b/lib/buttons/button_common.dart
@@ -68,9 +68,13 @@ Future<void> disableButtonWhileOnPressedExecutes({
   required EnabledSetter setEnabled,
   required FutureCallback onPressed,
 }) async {
-  setEnabled(false);
-  await onPressed();
-  setEnabled(true);
+  try {
+    setEnabled(false);
+    await onPressed();
+    setEnabled(true);
+  } finally {
+    setEnabled(true);
+  }
 }
 
 double matchParentWidth(BuildContext context) =>


### PR DESCRIPTION
reason I changed is single responsibility ( only user of button decide should or shouldn't enabled )
